### PR TITLE
Include "best with X" when filtering for "recommended with X"

### DIFF
--- a/app.js
+++ b/app.js
@@ -177,10 +177,17 @@ function get_widgets() {
       transformItems: function(items) {
         return items.map(function(game){
           players = [];
+          prev_num = null;
           game.players.forEach(function(num_players){
             match = num_players.level2.match(/^\d+\ >\ ([\w\ ]+)\ (?:with|allows)\ (\d+\+?)$/);
             type = match[1].toLowerCase();
             num = match[2];
+
+            if (prev_num === num) {
+              // Already included as "best" for this number of players
+              return;
+            }
+            prev_num = num;
 
             type_callback = {
               'best': function(num) { return '<strong>' + num + '</strong><span title="Best with">★</span>'; },


### PR DESCRIPTION
Often, I want to view games that are either classed as "best with X" players or "recommended with X" players. However, there doesn't seem to be a way to select multiple options in the hierarchical menu. To allow for showing this, include the list of games ranked as "best with X" when filtering for "recommended with X".

I didn't find a way to include entries with one facet in the search result for another facet, so instead the indexer adds the "recommended with X" facet for games that are "best with X", with the app code skipping this additional facet when rendering the game widget to avoid the same number of players appearing twice.