### PR TITLE
Fix for syntax error: `&&` is not logical-and

### DIFF
--- a/scripts/mybgg/indexer.py
+++ b/scripts/mybgg/indexer.py
@@ -106,7 +106,7 @@ class Indexer:
     def add_objects(self, collection):
         games = [Indexer.todict(game) for game in collection]
         for i, game in enumerate(games):
-            if i != 0 && i % 25 == 0:
+            if i != 0 and i % 25 == 0:
                 print(f"Indexed {i} of {len(games)} games...")
 
             if game["image"]:


### PR DESCRIPTION
I have the following error being produced on the latest master commit:

```
Traceback (most recent call last):
  File "scripts/download_and_index.py", line 4, in <module>
    from mybgg.indexer import Indexer
  File "/mnt/c/git/mybgg/scripts/mybgg/indexer.py", line 109
    if i != 0 && i % 25 == 0:
               ^
SyntaxError: invalid syntax
```

Simple enough to fix, the `&&` should be `and`