### PR TITLE
Filter by previous players

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ Using this project, you can set up your own site for searching and filtering you
       {
           "project": {
               "name": "mybgg",  // This is the name of your project. You can leave it as it is.
-              "title": ""  // This is the page title. If you leave this empty, a title will be
+              "title": "",  // This is the page title. If you leave this empty, a title will be
                            // created from your BGG username.
+              "show_previous_players": false // If you want the ability to filter by players who have previous played this game
+                                             // (based on your logged plays), set this to true
           },
           "boardgamegeek": {
               "user_name": "YOUR_BGG_USERNAME",  // The username on boardgamegeek that has your games

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Using this project, you can set up your own site for searching and filtering you
               "name": "mybgg",  // This is the name of your project. You can leave it as it is.
               "title": "",  // This is the page title. If you leave this empty, a title will be
                            // created from your BGG username.
-              "show_previous_players": false // If you want the ability to filter by players who have previous played this game
-                                             // (based on your logged plays), set this to true
+              "show_previous_players": false, // If you want the ability to filter by players who have previous played this game
+                                              // (based on your logged plays), set this to true
+              "show_total_plays": false // If you want the ability to filter by the number of times you have logged
+                                        // plays for each game in your collection, set this to true
           },
           "boardgamegeek": {
               "user_name": "YOUR_BGG_USERNAME",  // The username on boardgamegeek that has your games

--- a/app.js
+++ b/app.js
@@ -189,6 +189,21 @@ function get_widgets(SETTINGS) {
         showMore: true,
       }
     ),
+    "refine_numplays": panel('Total plays')(instantsearch.widgets.numericMenu)(
+      {
+        container: '#facet-numplays',
+        attribute: 'numplays',
+        items: [
+          { label: 'Any' }, 
+          { label: '0', end: 0 },
+          { label: '1', start: 1, end: 1 },
+          { label: '2-9', start: 2, end: 9 },
+          { label: '10-19', start: 10, end: 19 },
+          { label: '20-39', start: 20, end: 29 },
+          { label: '30+', start: 30 },
+        ]
+      }
+    ),
     "hits": instantsearch.widgets.hits({
       container: '#hits',
       transformItems: function(items) {
@@ -292,6 +307,9 @@ function init(SETTINGS) {
   ]
   if (SETTINGS.project.show_previous_players == true) {
     widgetsToDisplay.push(widgets["refine_previousplayers"])
+  }
+  if (SETTINGS.project.show_total_plays == true) {
+    widgetsToDisplay.push(widgets["refine_numplays"])
   }
   search.addWidgets(widgetsToDisplay);
 

--- a/app.js
+++ b/app.js
@@ -171,6 +171,15 @@ function get_widgets() {
         sortBy: function(a, b){ return PLAYING_TIME_ORDER.indexOf(a.name) - PLAYING_TIME_ORDER.indexOf(b.name); },
       }
     ),
+    "refine_previousplayers": panel('Previous players')(instantsearch.widgets.refinementList)(
+      {
+        container: '#facet-previous-players',
+        attribute: 'previous_players',
+        operator: 'and',
+        searchable: true,
+        showMore: true,
+      }
+    ),
     "hits": instantsearch.widgets.hits({
       container: '#hits',
       transformItems: function(items) {
@@ -196,6 +205,7 @@ function get_widgets() {
 
           game.categories = game.categories.join(", ");
           game.mechanics = game.mechanics.join(", ");
+          game.previous_players = game.previous_players.join(", ");
           game.tags = game.tags.join(", ");
           game.description = game.description.trim();
 
@@ -243,6 +253,7 @@ function init(SETTINGS) {
     widgets["refine_players"],
     widgets["refine_weight"],
     widgets["refine_playingtime"],
+    widgets["refine_previousplayers"],
     widgets["hits"],
     widgets["stats"],
     widgets["pagination"],

--- a/app.js
+++ b/app.js
@@ -199,7 +199,7 @@ function get_widgets(SETTINGS) {
           { label: '1', start: 1, end: 1 },
           { label: '2-9', start: 2, end: 9 },
           { label: '10-19', start: 10, end: 19 },
-          { label: '20-39', start: 20, end: 29 },
+          { label: '20-29', start: 20, end: 29 },
           { label: '30+', start: 30 },
         ]
       }

--- a/app.js
+++ b/app.js
@@ -244,8 +244,7 @@ function init(SETTINGS) {
   search.on('render', on_render);
 
   var widgets = get_widgets();
-
-  search.addWidgets([
+  var widgetsToDisplay = [
     widgets["search"],
     widgets["clear"],
     widgets["refine_categories"],
@@ -253,11 +252,14 @@ function init(SETTINGS) {
     widgets["refine_players"],
     widgets["refine_weight"],
     widgets["refine_playingtime"],
-    widgets["refine_previousplayers"],
     widgets["hits"],
     widgets["stats"],
     widgets["pagination"],
-  ]);
+  ]
+  if (SETTINGS.project.show_previous_players == true) {
+    widgetsToDisplay.push(widgets["refine_previousplayers"])
+  }
+  search.addWidgets(widgetsToDisplay);
 
   search.start();
 

--- a/config.json
+++ b/config.json
@@ -2,7 +2,8 @@
     "project": {
         "name": "mybgg",
         "title": "",
-        "show_previous_players": false
+        "show_previous_players": false,
+        "show_total_plays": false
     },
     "boardgamegeek": {
         "user_name": "YOUR_BGG_USERNAME",

--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
     "project": {
         "name": "mybgg",
-        "title": ""
+        "title": "",
+        "show_previous_players": false
     },
     "boardgamegeek": {
         "user_name": "YOUR_BGG_USERNAME",

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
       <div class="facet" id="facet-categories" tabindex="0"></div>
       <div class="facet" id="facet-mechanics" tabindex="0"></div>
       <div class="facet" id="facet-previous-players" tabindex="0"></div>
+      <div class="facet" id="facet-numplays" tabindex="0"></div>
       <div class="clear-all" id="clear-all"></div>
     </aside>
     <main class="results">

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
       <div class="facet" id="facet-weight" tabindex="0"></div>
       <div class="facet" id="facet-categories" tabindex="0"></div>
       <div class="facet" id="facet-mechanics" tabindex="0"></div>
+      <div class="facet" id="facet-previous-players" tabindex="0"></div>
       <div class="clear-all" id="clear-all"></div>
     </aside>
     <main class="results">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@3.4.0/dist/instantsearch.development.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.1.1/themes/reset-min.css">
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,700&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,700&amp;display=swap">
 </head>
 <body>
   <header class="search">

--- a/scripts/download_and_index.py
+++ b/scripts/download_and_index.py
@@ -15,6 +15,7 @@ def main(args):
     collection = downloader.collection(
         user_name=SETTINGS["boardgamegeek"]["user_name"],
         extra_params=SETTINGS["boardgamegeek"]["extra_params"],
+        download_plays=SETTINGS["project"]["show_previous_players"] if "show_previous_players" in SETTINGS["project"] else False,
     )
     num_games = len(collection)
     num_expansions = sum([len(game.expansions) for game in collection])

--- a/scripts/mybgg/bgg_client.py
+++ b/scripts/mybgg/bgg_client.py
@@ -27,10 +27,11 @@ class BGGClient:
         collection = self._collection_to_games(data)
         return collection
 
-    def plays(self, user_name, **kwargs):
-        params = kwargs.copy()
-        params["username"] = user_name
-        params["page"] = 1
+    def plays(self, user_name):
+        params = {
+            "username": user_name,
+            "page": 1,
+        }
         all_plays = []
 
         data = self._make_request("/plays?version=1", params)

--- a/scripts/mybgg/bgg_client.py
+++ b/scripts/mybgg/bgg_client.py
@@ -27,6 +27,23 @@ class BGGClient:
         collection = self._collection_to_games(data)
         return collection
 
+    def plays(self, user_name, **kwargs):
+        params = kwargs.copy()
+        params["username"] = user_name
+        params["page"] = 1
+        all_plays = []
+
+        data = self._make_request("/plays?version=1", params)
+        new_plays = self._plays_to_games(data)
+
+        while (len(new_plays) > 0):
+            all_plays = all_plays + new_plays
+            params["page"] += 1
+            data = self._make_request("/plays?version=1", params)
+            new_plays = self._plays_to_games(data)
+        
+        return all_plays
+
     def game_list(self, game_ids):
         if not game_ids:
             return []
@@ -85,6 +102,31 @@ class BGGClient:
             )
 
         return response.text
+
+    def _plays_to_games(self, data):
+        def after_players_hook(_, status):
+            return status["name"]
+        
+        plays_processor = xml.dictionary("plays", [
+            xml.array(
+                xml.dictionary('play', [
+                    xml.integer(".", attribute="id", alias="playid"),
+                    xml.dictionary('item', [
+                        xml.string(".", attribute="name", alias="gamename"),
+                        xml.integer(".", attribute="objectid", alias="gameid")
+                    ], alias='game'),
+                        xml.array(
+                            xml.dictionary('players/player', [
+                                    xml.string(".", attribute="name")
+                            ], alias='players', hooks=xml.Hooks(after_parse=after_players_hook))
+                        )
+                    
+                ], required=False, alias="plays")
+            )
+        ])
+        plays = xml.parse_from_string(plays_processor, data)
+        plays = plays["plays"]
+        return plays
 
     def _collection_to_games(self, data):
         def after_status_hook(_, status):

--- a/scripts/mybgg/downloader.py
+++ b/scripts/mybgg/downloader.py
@@ -42,6 +42,7 @@ class Downloader():
         game_list_data = self.client.game_list([game_in_collection["id"] for game_in_collection in collection_data])
         game_id_to_tags = {game["id"]: game["tags"] for game in collection_data}
         game_id_to_image = {game["id"]: game["image_version"] or game["image"] for game in collection_data}
+        game_id_to_numplays = {game["id"]: game["numplays"] for game in collection_data}
 
         game_id_to_players = {game["id"]: [] for game in collection_data}
         for play in plays_data:
@@ -63,6 +64,7 @@ class Downloader():
                 game_data,
                 image=game_id_to_image[game_data["id"]],
                 tags=game_id_to_tags[game_data["id"]],
+                numplays=game_id_to_numplays[game_data["id"]],
                 previous_players=game_id_to_players[game_data["id"]],
                 expansions=[
                     BoardGame(expansion_data)

--- a/scripts/mybgg/downloader.py
+++ b/scripts/mybgg/downloader.py
@@ -18,7 +18,7 @@ class Downloader():
                 debug=debug,
             )
 
-    def collection(self, user_name, extra_params):
+    def collection(self, user_name, extra_params, download_plays):
         collection_data = []
         plays_data = []
 
@@ -28,18 +28,16 @@ class Downloader():
                     user_name=user_name,
                     **params,
                 )
-                plays_data += self.client.plays(
-                    user_name=user_name,
-                )
         else:
             collection_data = self.client.collection(
                 user_name=user_name,
                 **extra_params,
             )
+
+        if (download_plays == True):
             plays_data = self.client.plays(
                 user_name=user_name,
             )
-
 
         game_list_data = self.client.game_list([game_in_collection["id"] for game_in_collection in collection_data])
         game_id_to_tags = {game["id"]: game["tags"] for game in collection_data}

--- a/scripts/mybgg/downloader.py
+++ b/scripts/mybgg/downloader.py
@@ -30,7 +30,6 @@ class Downloader():
                 )
                 plays_data += self.client.plays(
                     user_name=user_name,
-                    **params,
                 )
         else:
             collection_data = self.client.collection(
@@ -39,7 +38,6 @@ class Downloader():
             )
             plays_data = self.client.plays(
                 user_name=user_name,
-                **extra_params,
             )
 
 

--- a/scripts/mybgg/indexer.py
+++ b/scripts/mybgg/indexer.py
@@ -28,6 +28,7 @@ class Indexer:
                 'players',
                 'weight',
                 'playing_time',
+                'searchable(previous_players)',
             ],
             'customRanking': [sort_by],
             'highlightPreTag': '<strong class="highlight">',

--- a/scripts/mybgg/indexer.py
+++ b/scripts/mybgg/indexer.py
@@ -29,6 +29,7 @@ class Indexer:
                 'weight',
                 'playing_time',
                 'searchable(previous_players)',
+                'numplays',
             ],
             'customRanking': [sort_by],
             'highlightPreTag': '<strong class="highlight">',

--- a/scripts/mybgg/models.py
+++ b/scripts/mybgg/models.py
@@ -3,7 +3,7 @@ import html
 
 
 class BoardGame:
-    def __init__(self, game_data, image="", tags=[], expansions=[]):
+    def __init__(self, game_data, image="", tags=[], previous_players=[], expansions=[]):
         self.id = game_data["id"]
         self.name = game_data["name"]
         self.description = html.unescape(game_data["description"])
@@ -18,6 +18,7 @@ class BoardGame:
         self.rating = self.calc_rating(game_data)
         self.image = image
         self.tags = tags
+        self.previous_players = previous_players
         self.expansions = expansions
 
     def calc_num_players(self, game_data, expansions):

--- a/scripts/mybgg/models.py
+++ b/scripts/mybgg/models.py
@@ -3,7 +3,7 @@ import html
 
 
 class BoardGame:
-    def __init__(self, game_data, image="", tags=[], previous_players=[], expansions=[]):
+    def __init__(self, game_data, image="", tags=[], numplays=0, previous_players=[], expansions=[]):
         self.id = game_data["id"]
         self.name = game_data["name"]
         self.description = html.unescape(game_data["description"])
@@ -16,6 +16,7 @@ class BoardGame:
         self.usersrated = self.calc_usersrated(game_data)
         self.numowned = self.calc_numowned(game_data)
         self.rating = self.calc_rating(game_data)
+        self.numplays = numplays
         self.image = image
         self.tags = tags
         self.previous_players = previous_players


### PR DESCRIPTION
Sometimes I've found that my friends aren't in the mood to learn new games and would rather play something they're familiar with. This PR adds an option to filter games by players who have played them previously, based on the user's logged plays (I log mine with the [BG Stats app](https://www.bgstatsapp.com/), for example). If you have a group of friends looking for something familiar, you can filter by all members in the group to see what games have been played by all.

I'm assuming most users would not want this functionality, especially not by default; for example, in case they are sharing their instance of the app publicly with others. Therefore I have hidden this functionality behind a "show_previous_players" toggle in the main config.json file; anybody who does not explicitly set this to true, including older config versions that do not set this field at all, will have this functionality disabled in both the front and back end. 

As the number of different players in the filter is variable from person to person, I couldn't find a good way to organise them in the refinement list so that all could be scrolled through; the best I could come up with was setting it as a searchable filter. I'm very open to any suggestions of how this could be improved! :)