### PR TITLE
Sort from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Using this project, you can set up your own site for searching and filtering you
               "index_name": "YOUR_INDEX_NAME",  // All your games will be stored in something called an "index".
                                                 // You can create and index by going to "Indices" in the menu to the left.
                                                 // Click to create a new index, and give it a name. Put the name you choose here.
-              "hits_per_page": 48   // Number of games you want to show on each page
+              "hits_per_page": 48,  // Number of games you want to show on each page
+              "sort_by": "asc(name)"  // Default sort order before the user has searched for anything.
+                                      // Can be one of: asc(rank), desc(rating), desc(numrated), desc(numowned)
+                                      // "asc" stands for ascending, meaning lowest number first, desc the opposite
           }
       }
       ```

--- a/README.md
+++ b/README.md
@@ -51,10 +51,7 @@ Using this project, you can set up your own site for searching and filtering you
               "index_name": "YOUR_INDEX_NAME",  // All your games will be stored in something called an "index".
                                                 // You can create and index by going to "Indices" in the menu to the left.
                                                 // Click to create a new index, and give it a name. Put the name you choose here.
-              "hits_per_page": 48,  // Number of games you want to show on each page
-              "sort_by": "asc(name)"  // Default sort order before the user has searched for anything.
-                                      // Can be one of: asc(rank), desc(rating), desc(numrated), desc(numowned)
-                                      // "asc" stands for ascending, meaning lowest number first, desc the opposite
+              "hits_per_page": 48   // Number of games you want to show on each page
           }
       }
       ```

--- a/app.js
+++ b/app.js
@@ -122,6 +122,15 @@ function get_widgets() {
       container: '#search-box',
       placeholder: 'Search for games'
     }),
+    "sort": instantsearch.widgets.sortBy({
+      container: '#sort-by',
+      items: [
+        { label: 'Name', value:'BGG'},
+        { label: 'Rank/Rating', value:'bgg_rank_ascending'},
+        { label: 'Number of Ratings', value:'bgg_numrated_descending'},
+        { label: 'Number of Owners', value:'bgg_numowned_descending'},
+      ],
+    }),
     "clear": instantsearch.widgets.clearRefinements({
       container: '#clear-all',
       templates: {
@@ -237,6 +246,7 @@ function init(SETTINGS) {
 
   search.addWidgets([
     widgets["search"],
+    widgets["sort"],
     widgets["clear"],
     widgets["refine_categories"],
     widgets["refine_mechanics"],

--- a/app.js
+++ b/app.js
@@ -125,11 +125,11 @@ function get_widgets(SETTINGS) {
     "sort": instantsearch.widgets.sortBy({
       container: '#sort-by',
       items: [
-        { label: 'Name', value:SETTINGS.algolia.index_name},
-        { label: 'Rank/Rating', value:'bgg_rank_ascending'},
-        { label: 'Number of Ratings', value:'bgg_numrated_descending'},
-        { label: 'Number of Owners', value:'bgg_numowned_descending'},
-      ],
+        {label: 'Name', value: SETTINGS.algolia.index_name},
+        {label: 'BGG Rank', value: 'bgg_rank_ascending'},
+        {label: 'Number of ratings', value: 'bgg_numrated_descending'},
+        {label: 'Number of owners', value: 'bgg_numowned_descending'}
+      ]
     }),
     "clear": instantsearch.widgets.clearRefinements({
       container: '#clear-all',

--- a/app.js
+++ b/app.js
@@ -233,29 +233,26 @@ function get_widgets(SETTINGS) {
 function init(SETTINGS) {
 
   var configIndexName = ''
-  if (SETTINGS.algolia.sort_by == null) {
-    //If not specified, default to sort by name
-    configIndexName = SETTINGS.algolia.index_name
-  } else {
-    switch (SETTINGS.algolia.sort_by) {
-      case 'asc(name)':
-        configIndexName = SETTINGS.algolia.index_name
-        break
-      case 'asc(rank)':
-      case 'desc(rating)':
-        configIndexName = 'bgg_rank_ascending'
-        break
-      case 'desc(numrated)':
-        configIndexName = 'bgg_numrated_descending'
-        break
-      case 'desc(numowned)':
-        configIndexName = 'bgg_numowned_descending'
-        break
-      default:
-        console.error("The provided config value for algolia.sort_by was invalid: " + SETTINGS.algolia.sort_by)
-        break;
-    }
+  switch (SETTINGS.algolia.sort_by) {
+    case undefined:
+    case 'asc(name)':
+      configIndexName = SETTINGS.algolia.index_name
+      break
+    case 'asc(rank)':
+    case 'desc(rating)':
+      configIndexName = 'bgg_rank_ascending'
+      break
+    case 'desc(numrated)':
+      configIndexName = 'bgg_numrated_descending'
+      break
+    case 'desc(numowned)':
+      configIndexName = 'bgg_numowned_descending'
+      break
+    default:
+      console.error("The provided config value for algolia.sort_by was invalid: " + SETTINGS.algolia.sort_by)
+      break;
   }
+  
 
   const search = instantsearch({
     indexName: configIndexName,

--- a/app.js
+++ b/app.js
@@ -231,8 +231,34 @@ function get_widgets(SETTINGS) {
 
 
 function init(SETTINGS) {
+
+  var configIndexName = ''
+  if (SETTINGS.algolia.sort_by == null) {
+    //If not specified, default to sort by name
+    configIndexName = SETTINGS.algolia.index_name
+  } else {
+    switch (SETTINGS.algolia.sort_by) {
+      case 'asc(name)':
+        configIndexName = SETTINGS.algolia.index_name
+        break
+      case 'asc(rank)':
+      case 'desc(rating)':
+        configIndexName = 'bgg_rank_ascending'
+        break
+      case 'desc(numrated)':
+        configIndexName = 'bgg_numrated_descending'
+        break
+      case 'desc(numowned)':
+        configIndexName = 'bgg_numowned_descending'
+        break
+      default:
+        console.error("The provided config value for algolia.sort_by was invalid: " + SETTINGS.algolia.sort_by)
+        break;
+    }
+  }
+
   const search = instantsearch({
-    indexName: SETTINGS.algolia.index_name,
+    indexName: configIndexName,
     searchClient: algoliasearch(
       SETTINGS.algolia.app_id,
       SETTINGS.algolia.api_key_search_only

--- a/app.js
+++ b/app.js
@@ -253,7 +253,6 @@ function init(SETTINGS) {
       break;
   }
   
-
   const search = instantsearch({
     indexName: configIndexName,
     searchClient: algoliasearch(

--- a/app.js
+++ b/app.js
@@ -90,7 +90,7 @@ function on_render() {
   });
 }
 
-function get_widgets() {
+function get_widgets(SETTINGS) {
   const WEIGHT_LABELS = [
     "Light",
     "Light Medium",
@@ -125,7 +125,7 @@ function get_widgets() {
     "sort": instantsearch.widgets.sortBy({
       container: '#sort-by',
       items: [
-        { label: 'Name', value:'BGG'},
+        { label: 'Name', value:SETTINGS.algolia.index_name},
         { label: 'Rank/Rating', value:'bgg_rank_ascending'},
         { label: 'Number of Ratings', value:'bgg_numrated_descending'},
         { label: 'Number of Owners', value:'bgg_numowned_descending'},
@@ -242,7 +242,7 @@ function init(SETTINGS) {
 
   search.on('render', on_render);
 
-  var widgets = get_widgets();
+  var widgets = get_widgets(SETTINGS);
 
   search.addWidgets([
     widgets["search"],

--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
   <header class="search">
     <img class="logo" src="favicon.ico" height="36" width="36">
     <div class="search-box" id="search-box"></div>
+    <label>Sort by:</label>
+    <div class="sort-by" id="sort-by"></div>
     <div class="stats" id="stats"></div>
     <a class="ref" href="https://www.algolia.com"><img src="search-by-algolia.png" width="130" height="18"></a>
   </header>

--- a/scripts/download_and_index.py
+++ b/scripts/download_and_index.py
@@ -30,7 +30,6 @@ def main(args):
             apikey=args.apikey,
             index_name=SETTINGS["algolia"]["index_name"],
             hits_per_page=hits_per_page,
-            sort_by=SETTINGS["algolia"].get("sort_by", "asc(name)"),
         )
         indexer.add_objects(collection)
         indexer.delete_objects_not_in(collection)

--- a/scripts/mybgg/indexer.py
+++ b/scripts/mybgg/indexer.py
@@ -10,7 +10,8 @@ from PIL import Image, ImageFile
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 class Indexer:
-    def __init__(self, app_id, apikey, index_name, hits_per_page, sort_by):
+        
+    def __init__(self, app_id, apikey, index_name, hits_per_page):
         client = SearchClient.create(
             app_id=app_id,
             api_key=apikey,
@@ -29,13 +30,34 @@ class Indexer:
                 'weight',
                 'playing_time',
             ],
-            'customRanking': [sort_by],
+            'customRanking': "asc(name)", #the default sort order for the main index
             'highlightPreTag': '<strong class="highlight">',
             'highlightPostTag': '</strong>',
             'hitsPerPage': hits_per_page,
         })
+        
+        self._init_replicas(client, index)
 
         self.index = index
+    
+    def _init_replicas(self, client, mainIndex):
+        
+        mainIndex.set_settings({
+            'replicas': [
+                'bgg_rank_ascending',
+                'bgg_numrated_descending',
+                'bgg_numowned_descending',
+            ]
+        })
+               
+        replica_index = client.init_index('bgg_rank_ascending')
+        replica_index.set_settings({'ranking': ['asc(rank)']})
+        
+        replica_index = client.init_index('bgg_numrated_descending')
+        replica_index.set_settings({'ranking': ['desc(usersrated)']})
+        
+        replica_index = client.init_index('bgg_numowned_descending')
+        replica_index.set_settings({'ranking': ['desc(numowned)']})
 
     @staticmethod
     def todict(obj):

--- a/scripts/mybgg/indexer.py
+++ b/scripts/mybgg/indexer.py
@@ -10,7 +10,7 @@ from PIL import Image, ImageFile
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 class Indexer:
-        
+
     def __init__(self, app_id, apikey, index_name, hits_per_page):
         client = SearchClient.create(
             app_id=app_id,
@@ -30,18 +30,18 @@ class Indexer:
                 'weight',
                 'playing_time',
             ],
-            'customRanking': ['asc(name)'], #the default sort order for the main index
+            'customRanking': ['asc(name)'],
             'highlightPreTag': '<strong class="highlight">',
             'highlightPostTag': '</strong>',
             'hitsPerPage': hits_per_page,
         })
-        
+
         self._init_replicas(client, index)
 
         self.index = index
-    
+
     def _init_replicas(self, client, mainIndex):
-        
+
         mainIndex.set_settings({
             'replicas': [
                 'bgg_rank_ascending',
@@ -49,13 +49,13 @@ class Indexer:
                 'bgg_numowned_descending',
             ]
         })
-               
+
         replica_index = client.init_index('bgg_rank_ascending')
         replica_index.set_settings({'ranking': ['asc(rank)']})
-        
+
         replica_index = client.init_index('bgg_numrated_descending')
         replica_index.set_settings({'ranking': ['desc(usersrated)']})
-        
+
         replica_index = client.init_index('bgg_numowned_descending')
         replica_index.set_settings({'ranking': ['desc(numowned)']})
 

--- a/scripts/mybgg/indexer.py
+++ b/scripts/mybgg/indexer.py
@@ -30,7 +30,7 @@ class Indexer:
                 'weight',
                 'playing_time',
             ],
-            'customRanking': "asc(name)", #the default sort order for the main index
+            'customRanking': ['asc(name)'], #the default sort order for the main index
             'highlightPreTag': '<strong class="highlight">',
             'highlightPostTag': '</strong>',
             'hitsPerPage': hits_per_page,

--- a/style.css
+++ b/style.css
@@ -69,6 +69,28 @@ body {
 .logo {
     margin-right: 1em;
 }
+.sort-by {
+    max-width: 150px;
+    margin-right: 1em;
+    margin-left: 0.3em;
+    flex-grow: 1;
+}
+    .ais-SortBy-select {
+        position: relative;
+        font-size: 14px;
+        width: 100%;
+        min-width: 150px;
+        appearance: none;
+        font: inherit;
+        background: #fff;
+        border: 1px solid rgba(0,0,0,0.05);
+        border-radius: 4px;
+        padding: 10px 2px 10px 5px;
+        vertical-align: middle;
+        white-space: normal;
+        height: 100%;
+        width: 100%;
+    }
 .search-box {
     max-width: 300px;
     margin-right: 1em;


### PR DESCRIPTION
As suggested in Issue #25 , this PR implements the ability to sort via the UI. It works by creating [replica indexes in Algolia](https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/in-depth/replicas/) and then using a sortBy in the UI to pick the appropriate index. 

This PR is a breaking change as the sort_by parameter in the config.json is no longer respected; now it will always default to sorting by name, and can only be updated via the UI. The reason for this is to avoid complex logic regarding removing a different replica index depending on which sort option was selected, or removing the default index entirely and then setting the sort option on load. 

One way to avoid a breaking change with this would be to disable this feature if the "sort_by" option is specified in the config file; that way, you either hard-code a sort or you allow sorting via the UI, but not both. Would love to hear others thoughts on whether this is a better approach. 

As I'm not a front-end developer, I haven't been able to make the sort field look particularly pretty in terms of layout and style - if anybody with better HTML and CSS skills than me wants to improve on this then please be my guest! 