### PR TITLE
Don't cache BGG's transient "please try again" collection response

### DIFF
--- a/scripts/gamecache/http_client.py
+++ b/scripts/gamecache/http_client.py
@@ -280,13 +280,19 @@ class CachedHttpClient:
             status_code = 200  # make_http_request only returns data on success
             response_headers = {}  # Simple implementation doesn't capture response headers
 
-            # Store in cache
-            cursor.execute("""
-                INSERT OR REPLACE INTO http_cache
-                (url_hash, url, response_data, headers, status_code, timestamp)
-                VALUES (?, ?, ?, ?, ?, ?)
-            """, (url_hash, full_url, response_data, json.dumps(response_headers), status_code, time_module.time()))
-            conn.commit()
+            # BGG returns this transient message (HTTP 202) while it prepares a collection
+            # export asynchronously. It must never be cached, or every retry - and every run
+            # for the next `expire_after` seconds - would just replay "try again" forever
+            # instead of re-checking BGG for the real data.
+            is_transient_bgg_message = b"has been accepted and will be processed" in response_data
+
+            if not is_transient_bgg_message:
+                cursor.execute("""
+                    INSERT OR REPLACE INTO http_cache
+                    (url_hash, url, response_data, headers, status_code, timestamp)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                """, (url_hash, full_url, response_data, json.dumps(response_headers), status_code, time_module.time()))
+                conn.commit()
 
         except Exception as e:
             conn.close()


### PR DESCRIPTION
## Summary
`CachedHttpClient.get()` in `scripts/gamecache/http_client.py` caches every successful HTTP response unconditionally - including BGG's async "please try again later" placeholder message that the collection endpoint returns while it prepares a `stats=1` export.

## The bug
1. BGG's `/collection` endpoint returns HTTP 202 with:
   ```xml
   <message>Your request for this collection has been accepted and will be processed. Please try again later for access.</message>
   ```
   while it builds the export. `urlopen` doesn't treat 202 as an error, so `make_http_request` returns this message as a normal response body.
2. `CachedHttpClient.get()` writes it into the SQLite cache with `status_code = 200` and the full `expire_after` TTL (24h via `Downloader`).
3. `BGGClient._make_request` sees the "has been accepted" message and retries via `sleep_with_backoff_and_jitter` - but every retry hits the same cache key, which now holds the placeholder, so it just keeps replaying "still processing" instead of ever re-checking BGG.
4. Because the retry backoff itself grows unboundedly (`10 * 2^tries`), this can look like `download_and_index.py --cache_bgg` has hung - in practice I saw it loop for over an hour, while a direct request to BGG (bypassing the local cache) was returning HTTP 200 with the full collection the whole time.

## Fix
Skip the cache write when the response body is BGG's transient message, so every retry actually reaches BGG instead of arguing with its own cache.

## Testing
Reproduced the hang locally (collection stuck retrying against a cached placeholder for well over an hour), applied this fix, cleared the cache, and confirmed a fresh run picks up BGG's real response immediately once it's ready, instead of re-caching the placeholder.